### PR TITLE
Fix bug 1404333: Be extra-sure there's no border around the enrollment message.

### DIFF
--- a/extension/content/about-pioneer/about-pioneer.css
+++ b/extension/content/about-pioneer/about-pioneer.css
@@ -120,7 +120,8 @@ a {
 
 .enroll-button.enrolled {
   background: none;
-  border: none;
+  border: none !important;
+  -moz-appearance: none;
   cursor: default;
 }
 


### PR DESCRIPTION
I can't replicate the issue locally or on a Windows 10 VM, but @gijsk recommended these changes as a possible fix.