### PR TITLE
Update to work on 57+

### DIFF
--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -80,14 +80,6 @@ function showNotification(doc, onClickButton) {
   notice.style.height = "40px";
   const messageText = doc.getAnonymousElementByAttribute(notice, "anonid", "messageText");
   messageText.style.color = "#333";
-  const closeButton = doc.getAnonymousNodes(notice)[0].childNodes[1];
-  if (closeButton) {
-    if (doc.defaultView.matchMedia("(min-resolution: 2dppx)").matches) {
-      closeButton.setAttribute("style", "-moz-image-region: rect(0, 32px, 32px, 0) !important;");
-    } else {
-      closeButton.setAttribute("style", "-moz-image-region: rect(0, 16px, 16px, 0) !important;");
-    }
-  }
 
   // Position the button next to the text like in Heartbeat
   const rightSpacer = doc.createElement("spacer");

--- a/extension/chrome.manifest
+++ b/extension/chrome.manifest
@@ -1,2 +1,2 @@
 resource pioneer-enrollment-study .
-resource pioneer-enrollment-study-content content/
+resource pioneer-enrollment-study-content content/ contentaccessible=yes

--- a/extension/install.rdf
+++ b/extension/install.rdf
@@ -6,7 +6,7 @@
     <em:type>2</em:type>
     <em:bootstrap>true</em:bootstrap>
     <em:unpack>false</em:unpack>
-    <em:version>2.0.3</em:version>
+    <em:version>2.0.4</em:version>
     <em:name>Pioneer Enrollment</em:name>
     <em:description>Prompts users to enroll in the Firefox Pioneer program.</em:description>
     <em:multiprocessCompatible>true</em:multiprocessCompatible>

--- a/extension/install.rdf
+++ b/extension/install.rdf
@@ -6,7 +6,7 @@
     <em:type>2</em:type>
     <em:bootstrap>true</em:bootstrap>
     <em:unpack>false</em:unpack>
-    <em:version>2.0.2</em:version>
+    <em:version>2.0.3</em:version>
     <em:name>Pioneer Enrollment</em:name>
     <em:description>Prompts users to enroll in the Firefox Pioneer program.</em:description>
     <em:multiprocessCompatible>true</em:multiprocessCompatible>
@@ -15,8 +15,8 @@
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!--Firefox-->
-        <em:minVersion>56.0</em:minVersion>
-        <em:maxVersion>56.*</em:maxVersion>
+        <em:minVersion>57.0</em:minVersion>
+        <em:maxVersion>*</em:maxVersion>
       </Description>
     </em:targetApplication>
   </Description>


### PR DESCRIPTION
This fixes two issues with the add-on that prevent it from running in Firefox 57 and above:

1. The content files were not marked as `contentaccessible=yes` in the manifest, making them unaccessible from `about:pioneer`.
2. The CSS fixes to the close button are unnecessary on 57+. See https://github.com/mozilla/normandy/commit/ab110e2f6a7bcab0ae126136ce0d37f9605c7956 for more info.

The CSS fixes make the close button look incorrect on 56 (I think. This is going off of memory.), so I updated the version range to 57 and higher. A signed version of this add-on already exists on the S3 signing bucket, but it has the wrong version range (it includes 56). When uploading the built version of this to Normandy, please make sure to rebuild and resign from source instead of reusing that one.