### PR TITLE
Update use of RecentWindow.jsm to BrowserWindowTracker.jsm.

### DIFF
--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -8,6 +8,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "config",
   "resource://pioneer-enrollment-study/Config.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "RecentWindow",
   "resource:///modules/RecentWindow.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "BrowserWindowTracker",
+  "resource:///modules/BrowserWindowTracker.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "AboutPages",
   "resource://pioneer-enrollment-study-content/AboutPages.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "AddonManager",
@@ -90,10 +92,19 @@ function showNotification(doc, onClickButton) {
 }
 
 function getMostRecentBrowserWindow() {
-  return RecentWindow.getMostRecentBrowserWindow({
-    private: false,
-    allowPopups: false,
-  });
+  // Attempt to use newer BrowserWindowTracker API, and fallback to older
+  // RecentWindow API if that fails.
+  try {
+    return BrowserWindowTracker.getTopWindow({
+      private: false,
+      allowPopups: false,
+    });
+  } catch (err) {
+    return RecentWindow.getMostRecentBrowserWindow({
+      private: false,
+      allowPopups: false,
+    });
+  }
 }
 
 function getEnrollmentState() {


### PR DESCRIPTION
See [bug 1034036](https://bugzilla.mozilla.org/show_bug.cgi?id=1034036) and [this email](https://mail.mozilla.org/pipermail/firefox-dev/2018-April/006379.html) for the change in mozilla-central that requires this.

The change is currently on autoland, so it isn't even fully landed yet, let alone in Nightly, so you won't be able to properly test this until the patches in [bug 1034036](https://bugzilla.mozilla.org/show_bug.cgi?id=1034036) are merged and make it into a Nightly build.

This attempts to be backwards-compatible (since lazy imports won't throw until you access them), so the resulting add-on should work on current versions and Nightlies that have the change.

I'm not set up to test this at all, so I haven't. At a minimum, a manual run through of a build with this change would be good to do. 

Someone else will also have to handle deploying this since I've lost all the access I'd need to do so.

@mythmon r?

CC @gregglind